### PR TITLE
Remove plugin prefix

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -5,7 +5,7 @@ namespace :deploy do
 
       This is similar to running:
 
-          bin/cake Migrations.migrations migrate
+          bin/cake migrations migrate
 
       For help:
 
@@ -21,7 +21,7 @@ namespace :deploy do
 
       This is similar to running:
 
-          bin/cake Migrations.migrations rollback
+          bin/cake migrations rollback
 
       For help:
 
@@ -40,7 +40,7 @@ namespace :cakephp do
     ask(:cmd, "list")
     command = args[:command_name] || fetch(:cmd)
 
-    invoke "cakephp:cake", "Migrations.migrations", command, *args.extras
+    invoke "cakephp:cake", "migrations", command, *args.extras
   end
 
 end


### PR DESCRIPTION
Per the [upstream PR comments](https://github.com/jadb/capcake/pull/20):

> I just updated from CakePHP 3.4.12 to 3.5.0 along with cakephp/migrations to 1.7.1 and capcake migrations broke. Apparently the plugin dot notation of Migrations.migrations is no longer supported. The changes in the PR have been tested successfully with the above versions.

> Also tested: removing the plugin prefix does not break capcake's migrations with CakePHP v3.4.x and migration plugin v1.6.x.

Unfortunately it appears `jadb/capcake` is abandoned so adding the PR to my forked repo.
